### PR TITLE
New Plugin - Sololegends - temple-trek-bog-helper

### DIFF
--- a/plugins/temple-trek-bog-helper
+++ b/plugins/temple-trek-bog-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/sololegends/runelite-temple-trek-bog-helper.git
-commit=89d97fdf1c4aba14431b21e85a08544697b0226b
+commit=1e176009d4dce7ee734d40bd967e74c3531f56c6

--- a/plugins/temple-trek-bog-helper
+++ b/plugins/temple-trek-bog-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/sololegends/runelite-temple-trek-bog-helper.git
+commit=89d97fdf1c4aba14431b21e85a08544697b0226b


### PR DESCRIPTION
# Runelite Temple Trek Bog Helper
Highlights firm bog ground as you find them

During the bog event in Temple Trekking, as you discover tiles that are "firm" they will be highlighted automatically for you. These highlights will only persist for that single event and be reset when the bog puzzle resets.  

There is also a full on solver which automatically highlights all firm tiles without having to poke around in the bog.